### PR TITLE
Parent process id and recv() conventions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,10 @@ pub enum PidEvent {
     ///  PROC_EVENT_EXEC
     Exec(libc::c_int),
     ///  PROC_EVENT_FORK
-    Fork(libc::c_int),
+    Fork {
+        parent: libc::c_int,
+        pid: libc::c_int,
+    },
     /// PROC_EVENT_COREDUMP
     Coredump(libc::c_int),
     /// PROC_EVENT_EXIT
@@ -202,7 +205,8 @@ unsafe fn parse_msg(header: *const nlmsghdr) -> Option<PidEvent> {
     match (*proc_ev).what {
         binding::PROC_EVENT_FORK => {
             let pid = (*proc_ev).event_data.fork.child_pid;
-            Some(PidEvent::Fork(pid))
+            let parent = (*proc_ev).event_data.fork.parent_pid;
+            Some(PidEvent::Fork { parent, pid })
         }
         binding::PROC_EVENT_EXEC => {
             let pid = (*proc_ev).event_data.exec.process_pid;


### PR DESCRIPTION
First of all, thanks so much for the library, it's been working great for me!

I'd like to suggest a couple of changes for small limitations that I ran into:

1. **Include the parent pid in fork messages**
   In my use case, I want to track all processes that spawn from another or any of its descendants, but that was not really possibly without this key piece of information
2. **Do not return `None` from the `recv()` function unless the socket data stream has actually ended**
   I expected the `recv()` function to work like other blocking `recv()` functions, where a `None/Err` result signifies that the event stream has ended and there will not be any more, but in the original implementation that was not the case, and `None` values could be followed by `Some` values later on. This means that as a consumer I need to setup a polling system to check for new events regularly, which is not a great use of resources when the underlying implementation can instead wait for new data directly on the socket.